### PR TITLE
Add support for password file mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
           ports: '1883:1883 8883:8883'
           certificates: ${{ github.workspace }}/.ci/tls-certificates
           config: ${{ github.workspace }}/.ci/mosquitto.conf
+          password-file: ${{ github.workspace}}/.ci/mosquitto.passwd
           container-name: 'mqtt'
   
       - run: test
@@ -49,6 +50,7 @@ Currently, the following parameters are supported:
 | `ports`   | `1883:1883`   | Port mappings in a [host]:[container] format, delimited by spaces (example: "1883:1883 8883:8883") |
 | `certificates` | -   | Absolute path to a directory containing certificate files which can be referenced in the config (the folder is mounted under `/mosquitto-certs` in the container) |
 | `config`  | -        | Absolute path to a custom `mosquitto.conf` configuration file to use |
+| `password-file` | -  | Absolute path to a custom `mosquitto.passwd` password file which will be mounted at `/mosquitto/config/mosquitto.passwd` |
 | `container-name` | `mosquitto` | The name of the spawned Docker container (can be used as hostname when accessed from other containers) |
 
 All parameters are optional. If no `certificates` are given, no volume is mounted. If no `config` is given, the default Mosquitto config is used.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Absolute path to the mosquitto.conf configuration file to use'
     required: false
     default: ''
+  password-file:
+    description: 'Absolute path to the mosquitto.passwd password file to use'
+    required: false
+    default: ''
   container-name:
     description: 'The name of the spawned Docker container (can be used as hostname when accessed from other containers)'
     required: false
@@ -35,4 +39,5 @@ runs:
     - ${{ inputs.ports }}
     - ${{ inputs.certificates }}
     - ${{ inputs.config }}
+    - ${{ inputs.password-file }}
     - ${{ inputs.container-name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,8 @@ VERSION=$1
 PORTS=$2
 CERTIFICATES=$3
 CONFIG=$4
-CONTAINERNAME=$5
+PASSWORD_FILE=$5
+CONTAINERNAME=$6
 
 echo "Certificates: $CERTIFICATES"
 echo "Config: $CONFIG"
@@ -22,6 +23,10 @@ fi
 
 if [ -n "$CONFIG" ]; then
   docker_run="$docker_run --volume $CONFIG:/mosquitto/config/mosquitto.conf:ro"
+fi
+
+if [ -n "$PASSWORD_FILE" ]; then
+  docker_run="$docker_run --volume $PASSWORD_FILE:/mosquitto/config/mosquitto.passwd:ro"
 fi
 
 docker_run="$docker_run eclipse-mosquitto:$VERSION"


### PR DESCRIPTION
This PR adds a new `password-file` option which allows the user to mount a password file in the spawned Mosquitto container. The password file can then be referenced from the mounted `mosquitto.conf` configuration file using the path `/mosquitto/config/mosquitto.passwd`.